### PR TITLE
Suppress warnings generated by DOMDocument::loadHTML()

### DIFF
--- a/src/Supertext/Helper/Library.php
+++ b/src/Supertext/Helper/Library.php
@@ -276,8 +276,12 @@ class Library
     </html>
     ';
 
+    $libxml_use_internal_errors = libxml_use_internal_errors(true);
     $doc = new \DOMDocument();
     $doc->loadHTML($html);
+    libxml_clear_errors();
+    libxml_use_internal_errors($libxml_use_internal_errors);
+
     return $doc;
   }
 


### PR DESCRIPTION
`DOMDocument::loadHTML()` may throw some PHP warnings for unknown HTML. To suppress them we can use `libxml_use_internal_errors(false)`.

Some logged warnings:
<img width="712" alt="Bildschirmfoto 2021-11-24 um 10 37 39" src="https://user-images.githubusercontent.com/617637/143213213-a5166f50-0b3f-4ea5-9b1e-1bf084c73493.png">

WordPress is doing the same in several places:

* https://github.com/WordPress/wordpress-develop/blob/2648a5f984b8abf06872151898e3a61d3458a628/src/wp-includes/widgets/class-wp-widget-text.php#L128
* https://github.com/WordPress/wordpress-develop/blob/2648a5f984b8abf06872151898e3a61d3458a628/src/wp-includes/class-wp-oembed.php#L612
* https://github.com/WordPress/wordpress-importer/blob/e05f678835c60030ca23c9a186f50999e198a360/src/parsers/class-wxr-parser-simplexml.php#L20