### PR TITLE
Skip checking for translated post IDs for proofread order types

### DIFF
--- a/src/Supertext/Api/WriteBack.php
+++ b/src/Supertext/Api/WriteBack.php
@@ -57,10 +57,15 @@ class WriteBack
   public function isReferenceValid()
   {
     $sourcePostIds = $this->getSourcePostIds();
+    $orderType = $this->getOrderType();
 
     $referenceData = hex2bin(Constant::REFERENCE_BITMASK);
     foreach ($sourcePostIds as $sourcePostId) {
-      $targetPostId = $this->library->getMultilang()->getPostInLanguage($sourcePostId, $this->getTargetLanguageCode());
+      if('translation' == $orderType) {
+        $targetPostId = $this->library->getMultilang()->getPostInLanguage($sourcePostId, $this->getTargetLanguageCode());
+      } else {
+        $targetPostId = $sourcePostId;
+      }
       $writeBackMeta = $this->getWriteBackMeta($targetPostId);
       $referenceHash = $writeBackMeta->getReferenceHash();
       $referenceData ^= hex2bin($referenceHash);

--- a/src/Supertext/Backend/CallbackHandler.php
+++ b/src/Supertext/Backend/CallbackHandler.php
@@ -101,9 +101,14 @@ class CallbackHandler
   {
     $errors = array();
     $contentData = $writeBack->getContentData();
+    $orderType = $writeBack->getOrderType();
 
     foreach ($writeBack->getSourcePostIds() as $sourcePostId) {
-      $targetPostId = $this->library->getMultilang()->getPostInLanguage($sourcePostId, $writeBack->getTargetLanguageCode());
+      if('translation' == $orderType) {
+        $targetPostId = $this->library->getMultilang()->getPostInLanguage($sourcePostId, $writeBack->getTargetLanguageCode());
+      } else {
+        $targetPostId = $sourcePostId;
+      }
 
       if ($targetPostId == null) {
         $errors[$sourcePostId] = 'There is no linked post for saving the writeback.';


### PR DESCRIPTION
Fixes write back error `The post 13 was last ordered with order 0 for .` for proofread orders if neither Polylang nor WPML is installed.