### PR TITLE
Bump Tested up to WordPress 6.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: supertext, msebel, comotive
 Tags: internationalization, polylang, WPML, translation, service, supertext
 Requires at least: 4.0
-Tested up to: 5.7.1
+Tested up to: 6.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
With this change, it clears the following message

<img width="955" alt="image" src="https://user-images.githubusercontent.com/1785641/173029169-3c9b897d-7efb-4b5b-a59f-bb2b013153bd.png">

https://wordpress.org/plugins/polylang-supertext/